### PR TITLE
fix: 버튼 1개로 통일

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8080/api
+VITE_API_BASE_URL=http://localhost:8000/api

--- a/src/api/documents.ts
+++ b/src/api/documents.ts
@@ -13,11 +13,11 @@ export const uploadDocument = async (file: File) => {
   return response.data; // { documentId: string, filename: string, ... }
 };
 
-export const startConversion = async (documentId: string, format: string) => {
-  // Map our UI format strings or send directly, BE might expect specific enum
+export const startConversion = async (documentId: string, format = 'gfm') => {
+  // Map our UI format strings or send directly, BE expects 'gfm', 'commonmark', or 'markdown'
   let targetFormat = 'gfm';
-  if (format === 'CommonMark') targetFormat = 'commonmark';
-  if (format === 'AsciiDoc') targetFormat = 'asciidoc';
+  if (format === 'CommonMark' || format === 'commonmark') targetFormat = 'commonmark';
+  if (format === 'markdown') targetFormat = 'markdown';
 
   const response = await axios.post(
     `${API_BASE_URL}/documents/${documentId}/convert`,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FileUpload from '@/components/FileUpload';
-import FormatSelector from '@/components/home/FormatSelector';
 import Button from '@/components/common/Button';
 import { uploadDocument, startConversion } from '@/api/documents';
 
-const FORMATS = ['CommonMark', 'GitHub Flavored Markdown (GFM)', 'AsciiDoc'];
-
 const Home = () => {
   const [file, setFile] = useState<File | null>(null);
-  const [selectedFormat, setSelectedFormat] = useState<string>(FORMATS[0]);
-
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
@@ -33,8 +28,8 @@ const Home = () => {
       const uploadRes = await uploadDocument(file);
       const docId = uploadRes.documentId;
 
-      // 2. Start Conversion
-      await startConversion(docId, selectedFormat);
+      // 2. Start Conversion (defaults to 'gfm')
+      await startConversion(docId);
 
       // 3. Navigate to progress page with documentId
       navigate('/converting', { state: { documentId: docId } });
@@ -60,20 +55,13 @@ const Home = () => {
         )}
       </div>
 
-      {/* 2. 포맷 선택 영역 */}
-      <FormatSelector
-        formats={FORMATS}
-        selectedFormat={selectedFormat}
-        onSelectFormat={setSelectedFormat}
-      />
-
-      {/* 3. 액션 버튼 */}
+      {/* 2. 액션 버튼 */}
       <Button
         onClick={handleDownload}
         disabled={isLoading || !file}
-        className={`px-10 ${!file || isLoading ? '!bg-rose-300 !opacity-80 hover:!bg-rose-300 hover:!scale-100 active:!scale-100' : ''}`}
+        className={`px-10 mt-6 ${!file || isLoading ? '!bg-rose-300 !opacity-80 hover:!bg-rose-300 hover:!scale-100 active:!scale-100' : ''}`}
       >
-        {isLoading ? '준비 중...' : '변환 시작'}
+        {isLoading ? '준비 중...' : 'Markdown (GFM)으로 변환'}
       </Button>
     </div>
   );


### PR DESCRIPTION

문서 변환 화면의 다중 포맷 선택 기능을 제거하고, AI 파이프라인의 기본 변환 규격인 **Markdown (GFM)** 단일 변환 방식으로 개편했음.

1. **메인 페이지 UI 단순화 (`FE/src/pages/Home.tsx`)**
   - 불필요한 포맷 선택 버튼(`FormatSelector`) 및 관련 상태 제거
   - 변환 시작 버튼의 명칭을 `Markdown (GFM)으로 변환`으로 변경하여 직관성 향상
   - 변환 요청 시 API로 전달할 포맷 파라미터 고정

2. **API 통신 파라미터 기본값 지정 (`FE/src/api/documents.ts`)**
   - `startConversion` 함수의 `format` 인자 기본값을 `'gfm'`으로 설정하여 안정성 및 하위 호환성 확보
   - 백엔드에서 지원하지 않던 포맷(AsciiDoc 등) 전송 차단

검증 결과
- **타입 체킹**: `npx tsc --noEmit` 실행 결과 타입 에러 없음
- **프로덕션 빌드**: `npm run build` 실행 결과 성공적으로 번들 생성 완료